### PR TITLE
use global for node dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 
 // for compression
-var win = window;
-var doc = document || {};
+var win = require('global/window');
+var doc = require('global/document');
 var root = doc.documentElement || {};
 
 // detect if we need to use firefox KeyEvents vs KeyboardEvents

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "zuul": "~1.0.3"
   },
   "author": "Roman Shtylman <shtylman@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "global": "3.0.0"
+  }
 }


### PR DESCRIPTION
the `global` module allows you to use globals in node & browser
- 'global/window' returns `window` in browser & `global` in node
- 'global/document' returns `document` in browser & a new instance of `min-document` in browsers.

I've updated `min-document` so an upstream unit test that uses `synthetic-dom-events` runs in node correctly.
